### PR TITLE
fix(devnet): start in protocol version 11

### DIFF
--- a/config/devnet/shelley-genesis.json
+++ b/config/devnet/shelley-genesis.json
@@ -30,7 +30,7 @@
         "nOpt": 100,
         "poolDeposit": 0,
         "protocolVersion": {
-            "major": 9,
+            "major": 11,
             "minor": 0
         },
         "rho": 0.1,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Start the devnet in protocol version 11 to align with current network expectations and avoid mismatches.

Updated `config/devnet/shelley-genesis.json` to set `protocolVersion.major` to 11.

<sup>Written for commit 5a9fccb9022b03f0288fd79edeaf557886ef6285. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/docker-cardano-configs/pull/65?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated devnet protocol version configuration from version 9 to version 11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->